### PR TITLE
Allow user to leave email from facebook permissions.

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,4 +1,16 @@
 c
+@user.email
+c
+auth["info"]["email"]
+auth["info"]["email"] = "your_email@example.com"
+c
+auth["info"]["email"] = "whatever"
+c
+auth["info"]["email"]
+auth["info"]["email"] = ""
+auth["info"]["email"]
+auth
+c
 open_last_email.body
 open_last_email.decode_body
 open_last_email.raw_source

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,7 +33,7 @@ class ApplicationController < ActionController::Base
   end
 
   def require_complete_profile
-    unless current_user.phone && current_user.first_name
+    unless current_user.phone && current_user.first_name && current_user.email_confirmed
       redirect_to edit_user_url(current_user)
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,7 +16,6 @@ class UsersController < ApplicationController
     @user = current_user
 
     if @user.update(user_params)
-
       if @user.email_confirmed
         redirect_to user_url(@user),
           notice: "Account updated"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,11 @@ class User < ActiveRecord::Base
 
   validates :phone, length: { is: 12, allow_nil: true }
   validates :first_name, presence: true, allow_nil: true
-  validates :uid, :email, :session_token, presence: true, uniqueness: true
-  validates_format_of :email, :with => /\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/
+  validates :email, presence: true, allow_nil: true, uniqueness: true
+  validates :uid, :session_token, presence: true, uniqueness: true
+  validates_format_of :email,
+    :with => /\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/,
+    allow_nil: true
 
   before_create :create_confirmation_token
 
@@ -24,10 +27,17 @@ class User < ActiveRecord::Base
   end
 
   def self.create_with_omniauth(auth)
-    create! do |user|
-      user.provider = auth["provider"]
-      user.uid = auth["uid"]
-      user.email = auth["info"]["email"]
+    if auth["info"]["email"]
+      create! do |user|
+        user.provider = auth["provider"]
+        user.uid = auth["uid"]
+        user.email = auth["info"]["email"]
+      end
+    else
+      create! do |user|
+        user.provider = auth["provider"]
+        user.uid = auth["uid"]
+      end
     end
   end
 

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -10,7 +10,7 @@
     .form-fields
       .form-group
         = f.label :email, 'Your email address:'
-        = f.email_field :email, class: 'form-control'
+        = f.email_field :email, placeholder: 'Email', class: 'form-control'
         %span We'll send you email notifications.
 
       .form-group

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,7 +1,14 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :facebook, ENV['FACEBOOK_KEY'], ENV['FACEBOOK_SECRET']
+  provider :facebook, ENV['FACEBOOK_KEY'], ENV['FACEBOOK_SECRET'], {
+    scope: 'email',
+    display: 'popup'
+  }
   provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'], {
     scope: ['email', 'https://www.googleapis.com/auth/gmail.modify'],
     access_type: 'offline'
   }
 end
+
+OmniAuth.config.on_failure = Proc.new { |env|
+  OmniAuth::FailureEndpoint.new(env).redirect_to_failure
+}

--- a/db/migrate/20160102214042_remove_null_constraint_from_user_email.rb
+++ b/db/migrate/20160102214042_remove_null_constraint_from_user_email.rb
@@ -1,0 +1,5 @@
+class RemoveNullConstraintFromUserEmail < ActiveRecord::Migration
+  def change
+    change_column_null :users, :email, true
+  end
+end

--- a/db/migrate/20160102214511_remove_default_email_from_users.rb
+++ b/db/migrate/20160102214511_remove_default_email_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveDefaultEmailFromUsers < ActiveRecord::Migration
+  def change
+    change_column_default :users, :email, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151231152014) do
+ActiveRecord::Schema.define(version: 20160102214511) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,7 +38,7 @@ ActiveRecord::Schema.define(version: 20151231152014) do
   add_index "hostings", ["host_id"], name: "index_hostings_on_host_id", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",              default: "",    null: false
+    t.string   "email"
     t.inet     "current_sign_in_ip"
     t.datetime "created_at",                         null: false
     t.datetime "updated_at",                         null: false

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,8 +11,9 @@ RSpec.describe User, type: :model do
       .to raise_error ActiveRecord::RecordInvalid
   end
 
-  it "is not valid without an email" do
-    expect { FactoryGirl.create(:user, email: nil, phone: "2345678901") }
+  it "allows no email, but if present, can't be blank" do
+    expect(FactoryGirl.create(:user, phone: "2345678901", email: nil)).to be_valid
+    expect { FactoryGirl.create(:user, email: "", phone: "2345678901") }
       .to raise_error ActiveRecord::RecordInvalid
   end
 


### PR DESCRIPTION
Removes null constraints on db and adds allow_nil to model validations. Since we are using email verifications, there is no need to get it from omniauth providers, but if the user allows, it will be filled out. Also fixes app crashing if user cancels omniauth request.
Also changes controller callbacks to require email_confirmed on any page but user edit and the sign_in screen
Rewrite specs to accomodate

Fixes #38 