### PR TITLE
Feedback button to google form, ssl in production, fix reply_tos

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -17,7 +17,7 @@ class UserMailer < ApplicationMailer
     @visit, @hosting, @visitor, @host =
       visit.decorate, hosting.decorate, visit.user.decorate, hosting.host.decorate
     @results_url = visit_url(@visit)
-    mail(to: @visitor.email, reply_to: @host.email,
+    mail(to: @visitor.email,
       subject: "Bernie BNB - New host near #{@visit.zipcode}!",
       template_path: 'user_mailer', template_name: 'new_host_email')
   end
@@ -26,7 +26,8 @@ class UserMailer < ApplicationMailer
     @visit, @hosting, @visitor, @host =
       visit.decorate, hosting.decorate, visit.user.decorate, hosting.host.decorate
     @hosting_url = hosting_url(@hosting)
-    mail(to: @host.email, subject: "Bernie BNB - You've been contacted!",
+    mail(to: @host.email, reply_to: @visitor.email,
+      subject: "Bernie BNB - You've been contacted!",
       template_path: 'user_mailer', template_name: 'contact_host_email')
   end
 end

--- a/app/models/hosting.rb
+++ b/app/models/hosting.rb
@@ -26,7 +26,7 @@ class Hosting < ActiveRecord::Base
       .where("start_date >= ?", Date.today)
 
     if Rails.env.production?
-      nearby_visits = nearby_visits.where("host_id != (?)", current_user.id)
+      nearby_visits = nearby_visits.where("user_id != (?)", self.host_id)
     end
 
     nearby_visits.each do |visit|

--- a/app/models/hosting.rb
+++ b/app/models/hosting.rb
@@ -4,7 +4,7 @@ class Hosting < ActiveRecord::Base
 
   geocoded_by :zipcode
   after_validation :geocode
-  after_save :notify_nearby_visitors
+  after_create :notify_nearby_visitors
 
   belongs_to :host, class_name: "User", foreign_key: :host_id
   has_many :contacts

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -12,9 +12,9 @@ class Visit < ActiveRecord::Base
     available_hostings = Hosting
       .near(self.zipcode, 25, order: "distance")
       .where("max_guests >= ?", num_travelers)
-      
+
     if Rails.env.production?
-      return available_hostings.where("host_id != (?)", current_user.id)
+      return available_hostings.where("host_id != (?)", self.user_id)
     else
       return available_hostings
     end

--- a/app/views/visits/show.html.haml
+++ b/app/views/visits/show.html.haml
@@ -55,4 +55,7 @@
                     "aria-controls" => "#{ tab_id }" } Cancel
 
   %footer
-    %a.btn.btn-default.btn-lg.center-block Submit Feedback
+    = link_to "Submit Feedback",
+      "http://goo.gl/forms/T219vo5Wt4",
+      class: 'btn btn-default btn-lg center-block',
+      target: '_blank'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
Created a google form, the submit feedback button now leads there.

Changed production.rb to config.force_ssl = true

Contact host email now has reply_to set to visitor. Removed reply_to host from new host email