### PR TITLE
Fix edit visit and hosting forms

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,3 +1,7 @@
+c
+n
+s
+auth["info"]["email"]
 quit
 @email
 quit

--- a/app/views/hostings/_hosting_form.html.haml
+++ b/app/views/hostings/_hosting_form.html.haml
@@ -9,7 +9,10 @@
 
     .form-group
       = f.label :max_guests, "How many can you host?"
-      = f.select :max_guests, options_for_select((1..7).zip(1..7)), {}, {class: 'form-control'}
+      = f.select :max_guests,
+        options_for_select((1..7).zip(1..7), @hosting.max_guests || nil), 
+        {},
+        {class: 'form-control'}
       %span.hosting Preferred maximum number of guests.
 
   = f.submit "Save", class: 'btn btn-success btn-block btn-lg'

--- a/app/views/visits/_visit_form.html.haml
+++ b/app/views/visits/_visit_form.html.haml
@@ -19,7 +19,10 @@
 
     .form-group
       = f.label :num_travelers, "How many total travelers?"
-      = f.select :num_travelers, options_for_select((1..7).zip(1..7)), {}, { class: 'form-control' }
+      = f.select :num_travelers,
+        options_for_select((1..7).zip(1..7), @visit.num_travelers || nil),
+        {},
+        { class: 'form-control' }
       %span Including yourself.
 
   = f.submit "Contact Hosts", class: 'btn btn-success btn-block btn-lg'

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,7 +1,6 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :facebook, ENV['FACEBOOK_KEY'], ENV['FACEBOOK_SECRET'], {
-    scope: 'email',
-    display: 'popup'
+    scope: 'email'
   }
   provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'], {
     scope: "email,profile"


### PR DESCRIPTION
Now the edit form's selected max_guest and num_travelers defaults to the saved value when viewing the edit form.