### PR TITLE
Now supporting 6 digits (not 7) in last part of international phone numbers.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,10 +56,10 @@ class User < ActiveRecord::Base
   def phone_number_length
     return if phone.nil?
     if phone.size > 12
-      if phone[0] == '+' # international
-        if phone.size > 15
+      if phone[0] == '+' # international +DD XXX XXXXXX (2,3,6 chars)
+        if phone.size > 14
           self.errors.add(:phone, "number is too long")
-        elsif phone.size < 15
+        elsif phone.size < 14
           self.errors.add(:phone, "number is too short")
         end
       else # not international

--- a/spec/features/create_visit_spec.rb
+++ b/spec/features/create_visit_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "User Creates Visit", type: :feature do
   end
 
   scenario "creating a new international visit with available hosts" do
-    FactoryGirl.create(:user, phone: '+46 234-567-8901')
+    FactoryGirl.create(:user, phone: '+46 234-567890')
     FactoryGirl.create(:hosting, zipcode: '11211', max_guests: 10, host_id: User.last.id)
     create_visit(Date.current, Date.current + 1.days)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -87,24 +87,24 @@ RSpec.describe User, type: :model do
     expect(FactoryGirl.create(:user, phone: "1.404.555-1212")).to be_valid
   end
 
+  it "has a valid factory - international - leading '+' char - 14 chars" do
+    expect(FactoryGirl.create(:user, phone: "+45 404 555121")).to be_valid
+  end
+
   it "has a valid factory - with periods and leadning '1' - 15 chars" do
     expect(FactoryGirl.create(:user, phone: "1-(404)555.1212")).to be_valid
   end
 
   it "has a valid factory - international - leading '+' char - 15 chars" do
-    expect(FactoryGirl.create(:user, phone: "+45 404 5551212")).to be_valid
+    expect(FactoryGirl.create(:user, phone: "+45.404-555121")).to be_valid
   end
 
   it "has a valid factory - with periods and leadning '1' - 16 chars" do
     expect(FactoryGirl.create(:user, phone: "1-(404)-555.1212")).to be_valid
   end
 
-  it "has a valid factory - international - leading '+' char - 16 chars" do
-    expect(FactoryGirl.create(:user, phone: "+45.404-555-1212")).to be_valid
-  end
-
-  it "has a valid factory - international - leading '+' char - 18 chars" do
-    expect(FactoryGirl.create(:user, phone: "+45.(404)-555-1212")).to be_valid
+  it "has a valid factory - international - leading '+' char - 17 chars" do
+    expect(FactoryGirl.create(:user, phone: "+45.(404)-555121")).to be_valid
   end
 
   it "bad phone number -- 17 digits (too long) - 17 chars" do


### PR DESCRIPTION
Now supporting 6 digits (not 7) in last part of international phone numbers.
 * Example: +46 DD XXX XXX-XXX, not +46 DD XXX XXX-XXXX