### PR TITLE
Add Two Steps to 'Steps' Section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ We would love your help.
   4. To set up development environment, do the following:
     * Fork the repo at https://github.com/SandersForPresident/BernieBNB
     * Cloned it locally.
+    * Setup environment to use ruby 2.3.0
     * Do above steps 1-3.
+    * Run "bundle"
     * Run "rake db:create".
     * Run "rake db:migrate".
     * Run "rake db:setup".


### PR DESCRIPTION
Why:

* The user should be using the version of ruby that matches the project
* and they should run bundle to install all gems after they clone the
* project.

This change addresses the need by:

* Adding step in 'README' in which the user is reminded to use the correct verion of
  ruby.
* Adding step in 'README' in which the user is reminded to bundle.