### PR TITLE
Add contacts to Hostings

### DIFF
--- a/app/controllers/hostings_controller.rb
+++ b/app/controllers/hostings_controller.rb
@@ -48,6 +48,6 @@ class HostingsController < ApplicationController
   def hosting_params
     params
       .require(:hosting)
-      .permit(:zipcode, :max_guests)
+      .permit(:zipcode, :max_guests, :comment)
   end
 end

--- a/app/models/hosting.rb
+++ b/app/models/hosting.rb
@@ -1,7 +1,7 @@
 class Hosting < ActiveRecord::Base
   validates :zipcode, :max_guests, presence: true
   validates :zipcode, zipcode: { country_code: :es }
-
+  validates :comment, length: { maximum: 140 }
   geocoded_by :zipcode
   after_validation :geocode
   after_create :notify_nearby_visitors

--- a/app/views/hostings/_hosting_form.html.haml
+++ b/app/views/hostings/_hosting_form.html.haml
@@ -4,7 +4,7 @@
   .form-fields
     .form-group
       = f.label :zipcode, "Where are you located?"
-      = f.text_field :zipcode, class: 'form-control'
+      = f.text_field :zipcode, class: 'form-control', placeholder: "5-digit zipcode"
       %span.hosting Your zip code.
 
     .form-group
@@ -17,7 +17,7 @@
 
     .form-group
       = f.label :comment, "Do you have a message for your visitors?"
-      = f.text_field :comment, class: 'form-control'
+      = f.text_field :comment, class: 'form-control', placeholder: "Maximum 140 characters"
       %span.hosting e.g. number of available beds or accessible hours.
 
   = f.submit "Save", class: 'btn btn-success btn-block btn-lg'

--- a/app/views/hostings/_hosting_form.html.haml
+++ b/app/views/hostings/_hosting_form.html.haml
@@ -15,4 +15,9 @@
         {class: 'form-control'}
       %span.hosting Preferred maximum number of guests.
 
+    .form-group
+      = f.label :comment, "Do you have a message for your visitors?"
+      = f.text_field :comment, class: 'form-control'
+      %span.hosting e.g. number of available beds or accessible hours.
+
   = f.submit "Save", class: 'btn btn-success btn-block btn-lg'

--- a/app/views/visits/_contact_host_instructions.html.haml
+++ b/app/views/visits/_contact_host_instructions.html.haml
@@ -9,6 +9,10 @@
     %li - Your email address
     %li - Your phone number
   %p Then, #{ host_name } should contact you to work out the details.
+
+  - if hosting.comment?
+    %h3 Special Instructions from #{ host_name }:
+    %p #{ hosting.comment }
   = link_to "Send my contact info",
             "/contacts/#{ @visit.id }/#{ hosting.id }",
             method: "POST",

--- a/app/views/visits/_hosts.html.haml
+++ b/app/views/visits/_hosts.html.haml
@@ -22,6 +22,11 @@
             %span #{ hosting.zipcode } - #{ hosting.distance.round(1) } miles
           %li
             %small Space for #{ hosting.max_guests }
+          - if hosting.comment?
+            %li
+              %span Comments from host:
+              %p
+                %small #{ hosting.comment }
       %a{ href: "##{ tab_id }",
           "role" => "button",
           class: "btn btn-md #{ button_class } contact-button right",

--- a/app/views/visits/_hosts.html.haml
+++ b/app/views/visits/_hosts.html.haml
@@ -22,11 +22,6 @@
             %span #{ hosting.zipcode } - #{ hosting.distance.round(1) } miles
           %li
             %small Space for #{ hosting.max_guests }
-          - if hosting.comment?
-            %li
-              %span Comments from host:
-              %p
-                %small #{ hosting.comment }
       %a{ href: "##{ tab_id }",
           "role" => "button",
           class: "btn btn-md #{ button_class } contact-button right",

--- a/db/migrate/20160115215253_add_comment_to_hosting.rb
+++ b/db/migrate/20160115215253_add_comment_to_hosting.rb
@@ -1,0 +1,5 @@
+class AddCommentToHosting < ActiveRecord::Migration
+  def change
+    add_column :hostings, :comment, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160110202324) do
+ActiveRecord::Schema.define(version: 20160115215253) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20160110202324) do
     t.datetime "updated_at",                null: false
     t.integer  "host_id",                   null: false
     t.integer  "contact_count", default: 0, null: false
+    t.text     "comment"
   end
 
   add_index "hostings", ["host_id"], name: "index_hostings_on_host_id", using: :btree

--- a/spec/factories/hostings.rb
+++ b/spec/factories/hostings.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :hosting do |f|
     f.host_id { rand(1..5) }
     f.zipcode { 11211 }
-    f.comment { Faker::Lorem.paragraph(1) }
+    f.comment { Faker::Lorem.paragraph(1)[0...140] }
     f.max_guests { rand(1..10) }
   end
 

--- a/spec/factories/hostings.rb
+++ b/spec/factories/hostings.rb
@@ -1,7 +1,8 @@
 FactoryGirl.define do
   factory :hosting do |f|
     f.host_id { rand(1..5) }
-    f.zipcode { Faker::Address.zip }
+    f.zipcode { 11211 }
+    f.comment { Faker::Lorem.paragraph }
     f.max_guests { rand(1..10) }
   end
 

--- a/spec/factories/hostings.rb
+++ b/spec/factories/hostings.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :hosting do |f|
     f.host_id { rand(1..5) }
     f.zipcode { 11211 }
-    f.comment { Faker::Lorem.paragraph }
+    f.comment { Faker::Lorem.paragraph(1) }
     f.max_guests { rand(1..10) }
   end
 

--- a/spec/models/hosting_spec.rb
+++ b/spec/models/hosting_spec.rb
@@ -47,4 +47,12 @@ RSpec.describe Hosting, type: :model do
     expect { FactoryGirl.create(:hosting, zipcode: "ABC") }
       .to raise_error ActiveRecord::RecordInvalid
   end
+
+  it "is valid with a comment" do
+    expect(FactoryGirl.create(:hosting, comment: "3 bedrooms and 2 bathrooms")).to be_valid
+  end
+
+  it "is valid without a comment" do
+    expect(FactoryGirl.create(:hosting, comment: nil))
+  end
 end


### PR DESCRIPTION
Hosts can now leave a maximum 140-character comment, regarding special instructions to potential visitors.
This is displayed on the host results, right above the button to contact the host. We could also use this in the email that notifies users when a new host becomes available (not currently implemented).