### PR TITLE
fixing visit spec #195

### DIFF
--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe Visit, type: :model do
   it "valid if end date equals start date" do
     expect(FactoryGirl.create(:visit,
                               zipcode: "11211",
-                              start_date: Date.today,
-                              end_date: Date.today)
+                              start_date: Time.zone.now.to_date,
+                              end_date: Time.zone.now.to_date)
     ).to be_valid
   end
 


### PR DESCRIPTION
Hi Guys,

I was looking into this problem and realized that the spec is not taking into account the TZ changes of the validation that was added.  I changed that up in the spec to reflect that and now it passes.  Currently, the code, `Time.zone.now` will always return UTC unless otherwise set.  If you do just `Time.now` (which is what `Date.today` does), this will map to your local timezone settings (ie ENVs or local settings files).  

Normally, when dealing with TZs, we save the timezone for the user in some column and save all dates and times in UTC and then change them on the frontend since TZ display is a view/presentation problem.

I havent dug into the code that far so Im not sure if that would be feasible right now.


Let me know if you want me to make any other changes.


