### PR TITLE
Add soft delete to visit and host

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'high_voltage'
 gem 'travis'
 gem 'bugsnag'
 gem 'orderly'
+gem 'acts_as_paranoid', git: 'https://github.com/ActsAsParanoid/acts_as_paranoid.git'
 
 gem 'puma-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/ActsAsParanoid/acts_as_paranoid.git
+  revision: ab31723bc11c82bac144cfabd4631b26307bfde1
+  specs:
+    acts_as_paranoid (0.5.0.beta2)
+      activerecord (~> 4.0)
+      activesupport (~> 4.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -353,6 +361,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts_as_paranoid!
   bcrypt
   better_errors
   binding_of_caller

--- a/app/models/hosting.rb
+++ b/app/models/hosting.rb
@@ -2,8 +2,12 @@ class Hosting < ActiveRecord::Base
   validates :zipcode, :max_guests, presence: true
   validates :zipcode, zipcode: { country_code: :es }
   validates :comment, length: { maximum: 140 }
+
   geocoded_by :zipcode
   after_validation :geocode
+
+  acts_as_paranoid
+
   after_create :notify_nearby_visitors
 
   belongs_to :host, class_name: "User", foreign_key: :host_id

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -10,6 +10,8 @@ class Visit < ActiveRecord::Base
   geocoded_by :zipcode
   after_validation :geocode
 
+  acts_as_paranoid
+
   def validate_start_date_is_not_in_the_past
     errors.add(:start_date, :in_past) unless start_date >= Time.zone.now.beginning_of_day
   end
@@ -18,7 +20,7 @@ class Visit < ActiveRecord::Base
     available_hostings = Hosting
       .near(self, 25, order: 'contact_count, distance')
       .where("max_guests >= ?", num_travelers)
-    
+
     if Rails.env.production? or Rails.env.staging?
       # :nocov:
       return available_hostings.where("host_id != (?)", self.user_id)

--- a/app/views/hostings/_hosting_form.html.haml
+++ b/app/views/hostings/_hosting_form.html.haml
@@ -17,7 +17,7 @@
 
     .form-group
       = f.label :comment, "Do you have a message for your visitors?"
-      = f.text_field :comment, class: 'form-control', placeholder: "Maximum 140 characters"
+      = f.text_field :comment, class: 'form-control', placeholder: "Maximum 140 characters (optional)"
       %span.hosting e.g. number of available beds or accessible hours.
 
   = f.submit "Save", class: 'btn btn-success btn-block btn-lg'

--- a/app/views/visits/_contact_host_instructions.html.haml
+++ b/app/views/visits/_contact_host_instructions.html.haml
@@ -1,4 +1,8 @@
 %div
+  - if hosting.comment?
+    %h3 Message from #{ host_name }:
+    %p "#{ hosting.comment }"
+
   %h3 Contact #{ host_name }
   %p We'll email #{ host_name } your contact info, saying:
   %ul
@@ -10,9 +14,6 @@
     %li - Your phone number
   %p Then, #{ host_name } should contact you to work out the details.
 
-  - if hosting.comment?
-    %h3 Special Instructions from #{ host_name }:
-    %p #{ hosting.comment }
   = link_to "Send my contact info",
             "/contacts/#{ @visit.id }/#{ hosting.id }",
             method: "POST",

--- a/db/migrate/20160117195300_add_deleted_at_to_visit.rb
+++ b/db/migrate/20160117195300_add_deleted_at_to_visit.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToVisit < ActiveRecord::Migration
+  def change
+    add_column :visits, :deleted_at, :datetime
+  end
+end

--- a/db/migrate/20160117202231_add_deleted_at_to_hosting.rb
+++ b/db/migrate/20160117202231_add_deleted_at_to_hosting.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToHosting < ActiveRecord::Migration
+  def change
+    add_column :hostings, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160115215253) do
+ActiveRecord::Schema.define(version: 20160117202231) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 20160115215253) do
     t.integer  "host_id",                   null: false
     t.integer  "contact_count", default: 0, null: false
     t.text     "comment"
+    t.datetime "deleted_at"
   end
 
   add_index "hostings", ["host_id"], name: "index_hostings_on_host_id", using: :btree
@@ -68,6 +69,7 @@ ActiveRecord::Schema.define(version: 20160115215253) do
     t.float    "latitude",                  null: false
     t.float    "longitude",                 null: false
     t.integer  "user_id",                   null: false
+    t.datetime "deleted_at"
   end
 
   add_index "visits", ["user_id"], name: "index_visits_on_user_id", using: :btree

--- a/spec/factories/hostings.rb
+++ b/spec/factories/hostings.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :hosting do |f|
     f.host_id { rand(1..5) }
-    f.zipcode { 11211 }
+    f.zipcode { "11211" }
     f.comment { Faker::Lorem.paragraph(1)[0...140] }
     f.max_guests { rand(1..10) }
   end

--- a/spec/factories/visits.rb
+++ b/spec/factories/visits.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :visit do |f|
     f.user_id { rand(1..5) }
-    f.zipcode { Faker::Address.zip }
+    f.zipcode { "11211" }
     f.num_travelers { rand(1..5) }
     start = Faker::Date.forward(20)
     f.start_date start

--- a/spec/features/create_hosting_spec.rb
+++ b/spec/features/create_hosting_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe "User creates Host", type: :feature do
     expect(page).to have_content("11211 (10 guests)")
     delete_host
     expect(page).not_to have_content("11211 (10 guests)")
+    expect(Hosting.with_deleted.last).to_not be_nil
   end
 
   scenario "updating a hosting guest number" do

--- a/spec/features/create_visit_spec.rb
+++ b/spec/features/create_visit_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe "User Creates Visit", type: :feature do
     click_link 'Delete'
 
     expect(page).to_not have_content('11211')
+    expect(Visit.with_deleted.last).to_not be_nil
   end
 
   scenario "new host becomes available for visit" do

--- a/spec/models/hosting_spec.rb
+++ b/spec/models/hosting_spec.rb
@@ -55,4 +55,11 @@ RSpec.describe Hosting, type: :model do
   it "is valid without a comment" do
     expect(FactoryGirl.create(:hosting, comment: nil))
   end
+
+  it "is softly deleted" do
+    hosting = FactoryGirl.create(:hosting)
+    hosting.destroy
+    expect(Hosting.first).to be_nil
+    expect(Hosting.with_deleted.first).to eq(hosting)
+  end
 end

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -86,4 +86,10 @@ RSpec.describe Visit, type: :model do
     Timecop.return
   end
 
+  it "is softly deleted" do
+    visit = FactoryGirl.create(:visit)
+    visit.destroy
+    expect(Visit.first).to be_nil
+    expect(Visit.with_deleted.first).to eq(visit)
+  end
 end


### PR DESCRIPTION
We can now access deleted records using the acts_as_paranoid gem. This allows us to write code as if we were deleting rows normally, but still access them later. Finishes #187