### PR TITLE
Upgrade capybara and tins gems; Changed acts_as_paranoid to use 0.5.0.beta2 version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'high_voltage'
 gem 'travis'
 gem 'bugsnag'
 gem 'orderly'
-gem 'acts_as_paranoid', git: 'https://github.com/ActsAsParanoid/acts_as_paranoid.git'
+gem 'acts_as_paranoid', '0.5.0.beta2' # TO GET LATEST RELEASED.
 
 gem 'puma-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/ActsAsParanoid/acts_as_paranoid.git
-  revision: ab31723bc11c82bac144cfabd4631b26307bfde1
-  specs:
-    acts_as_paranoid (0.5.0.beta2)
-      activerecord (~> 4.0)
-      activesupport (~> 4.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -44,6 +36,9 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    acts_as_paranoid (0.5.0.beta2)
+      activerecord (~> 4.0)
+      activesupport (~> 4.0)
     addressable (2.4.0)
     arel (6.0.3)
     ast (2.2.0)
@@ -326,7 +321,7 @@ GEM
     tilt (2.0.2)
     timecop (0.8.0)
     timeliness (0.3.8)
-    tins (1.8.1)
+    tins (1.8.2)
     travis (1.8.2)
       backports
       faraday (~> 0.9)
@@ -362,7 +357,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  acts_as_paranoid!
+  acts_as_paranoid (= 0.5.0.beta2)
   bcrypt
   better_errors
   binding_of_caller

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,8 @@ GEM
       json (~> 1.7, >= 1.7.7)
     builder (3.2.2)
     byebug (8.2.1)
-    capybara (2.5.0)
+    capybara (2.6.0)
+      addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)


### PR DESCRIPTION
 * Upgrade capybara and tins gems.
 * Changed acts_as_paranoid to use 0.5.0.beta2 version. This version comes from rubygems.org instead of Github repo.