### PR TITLE
Stop using Date.today and Time.now

### DIFF
--- a/app/models/hosting.rb
+++ b/app/models/hosting.rb
@@ -27,7 +27,7 @@ class Hosting < ActiveRecord::Base
     nearby_visits = Visit
       .near(self, 25, order: "distance")
       .where("num_travelers <= ?", max_guests)
-      .where("start_date >= ?", Date.today)
+      .where("start_date >= ?", Time.zone.today)
 
     # :nocov:
     if Rails.env.production? or  Rails.env.staging?

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe Visit, type: :model do
     expect do
       FactoryGirl.create(:visit,
                          zipcode: "11211",
-                         start_date: Date.today + 5.days,
-                         end_date: Date.today)
+                         start_date: Time.zone.today + 5.days,
+                         end_date: Time.zone.today)
     end.to raise_error ActiveRecord::RecordInvalid
   end
 
@@ -75,13 +75,12 @@ RSpec.describe Visit, type: :model do
   end
 
   it "should be valid if visit's start_date > app start_date" do
-    skip "#195"
-    new_time = Time.now + 12.hours
+    new_time = Time.zone.now + 12.hours
     Timecop.travel(new_time)
     expect(FactoryGirl.create(:visit,
                               zipcode: "11211",
-                              start_date: Date.today,
-                              end_date: Date.today)
+                              start_date: Time.zone.today,
+                              end_date: Time.zone.today)
     ).to be_valid
     Timecop.return
   end


### PR DESCRIPTION
 * Based on this article: http://danilenko.org/2012/7/6/rails_timezones
   * Changed all "Date.today" to "Time.zone.today".
   * Changed all "Time.now" to "Time.zone.now".
   * Part of #202 solution
 * Removed "skip" from the one tests that was failing and it is passing now. #195.