### PR TITLE
Use city and state in views

### DIFF
--- a/app/decorators/hosting_decorator.rb
+++ b/app/decorators/hosting_decorator.rb
@@ -2,6 +2,8 @@ class HostingDecorator < Draper::Decorator
   delegate_all
 
   def short_details
-    "#{zipcode[0...5]} (#{max_guests} guests)"
+    location = city? && state? ? "#{city}, #{state.to_s}" : zipcode
+    guests = max_guests > 1 ? " (#{max_guests} guests)" : " (#{max_guests} guest)"
+    location << guests
   end
 end

--- a/app/decorators/visit_decorator.rb
+++ b/app/decorators/visit_decorator.rb
@@ -3,10 +3,8 @@ class VisitDecorator < Draper::Decorator
   delegate_all
 
   def short_details
-    starting = start_date.strftime("%m/%d")
-    ending = end_date.strftime("%m/%d")
-
-    "#{formatted_zip} (#{start_and_end_dates})"
+    details = city? && state? ? "#{city}, #{state.to_s}" : zipcode
+    details << " (#{start_and_end_dates})"
   end
 
   def formatted_zip

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -19,7 +19,7 @@ class UserMailer < ApplicationMailer
     @results_url = visit_url(@visit)
     mail(to: @visitor.email,
          from: "DO-NOT-REPLY@berniebnb.com",
-         subject: "Bernie BNB - New host near #{@visit.zipcode}!",
+         subject: "Bernie BNB - New host near #{@visit.city || @visit.zipcode}!",
          template_path: 'user_mailer', template_name: 'new_host_email')
   end
 

--- a/app/views/user_mailer/new_host_email.html.erb
+++ b/app/views/user_mailer/new_host_email.html.erb
@@ -1,7 +1,13 @@
 Hi <%= @visitor.first_name %>,
 <br><br>
-<%= @host.first_name %> just signed up with BernieBNB as a host <%= @hosting.distance_from(@visit).round(1) %> mi. from <%= @visit.zipcode %>.
+<%= @host.first_name %> just signed up with BernieBNB as a host <%= @hosting.distance_from(@visit).round(1) %> mi. from <%= @visit.city || @visit.zipcode %>.
 <br><br>
+<% if @hosting.comment %>
+  Message from <%= @host.first_name %>:<br>
+  <%= @hosting.comment %>
+  <br><br>
+<% end %>
+
 Do NOT reply to this email! Contact <%= @host.first_name %> by clicking this link: <%= link_to "Contact #{@host.first_name}", "#{ENV['MAILER_URL']}/contacts/email/#{ @visit.id }/#{ @hosting.id }" %>
 <br><br>
 If you have already found a host or want to stop receiving emails, update your search at: <%= link_to "Your Visit Page", edit_visit_url(@visit) %>

--- a/app/views/user_mailer/new_host_email.text.erb
+++ b/app/views/user_mailer/new_host_email.text.erb
@@ -1,6 +1,11 @@
 Hi <%= @visitor.first_name %>,
 
-<%= @host.first_name %> just signed up with BernieBNB as a host <%= @hosting.distance_from(@visit).round(1) %> mi. from <%= @visit.zipcode %>.
+<%= @host.first_name %> just signed up with BernieBNB as a host <%= @hosting.distance_from(@visit).round(1) %> mi. from <%= "#{@visit.city}, #{@visit.state}" || @visit.zipcode %>.
+
+<% if @hosting.comment %>
+  Message from <%= @host.first_name %>:
+  <%= @hosting.comment %>
+<% end %>
 
 Do NOT reply to this email! Send your contact info here: <%= visit_url(@visit) %>
 

--- a/app/views/visits/_hosts.html.haml
+++ b/app/views/visits/_hosts.html.haml
@@ -19,7 +19,7 @@
           %li
             %h2 #{ host_name }
           %li
-            %span #{ hosting.zipcode } - #{ hosting.distance.round(1) } miles
+            %span #{ hosting.city || hosting.zipcode } - #{ hosting.distance.round(1) } miles
           %li
             %small Space for #{ hosting.max_guests }
       %a{ href: "##{ tab_id }",

--- a/app/views/visits/show.html.haml
+++ b/app/views/visits/show.html.haml
@@ -4,7 +4,7 @@
     = render 'empty_visits'
   - else
     %header
-      %h1.hosts-heading Hosts near #{ @visit.zipcode }
+      %h1.hosts-heading Hosts near #{ @visit.city || @visit.zipcode }
       %span Contact any good matches below
     %div.panel-group#accordion{ "role" => 'tablist', "aria-multiselectable" => 'true' }
       = render "hosts", visit: @visit

--- a/spec/features/create_hosting_spec.rb
+++ b/spec/features/create_hosting_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "User creates Host", type: :feature do
     Geocoder.configure(:lookup => :test)
 
     Geocoder::Lookup::Test.add_stub(
-      "11211", [{'latitude' => 40.7093358, 'longitude' => -73.9565551}]
+      "11211", [{'latitude' => 40.7093358, 'longitude' => -73.9565551, 'city' => 'Brooklyn', 'state' => 'NY'}]
     )
 
     Geocoder::Lookup::Test.add_stub(
@@ -30,7 +30,7 @@ RSpec.describe "User creates Host", type: :feature do
 
   scenario "creating a new hosting" do
     create_host
-    expect(page).to have_content("11211 (10 guests)")
+    expect(page).to have_content("Brooklyn, NY (10 guests)")
   end
 
   scenario "creating a new hosting with blank fields" do
@@ -48,29 +48,34 @@ RSpec.describe "User creates Host", type: :feature do
 
   scenario "deleting a hosting" do
     create_host
-    expect(page).to have_content("11211 (10 guests)")
+    expect(page).to have_content("Brooklyn, NY (10 guests)")
     delete_host
-    expect(page).not_to have_content("11211 (10 guests)")
+    expect(page).not_to have_content("Brooklyn, NY (10 guests)")
     expect(Hosting.with_deleted.last).to_not be_nil
   end
 
   scenario "updating a hosting guest number" do
     create_host
-    expect(page).to have_content("11211 (10 guests)")
-    click_link '11211'
+    expect(page).to have_content("Brooklyn, NY (10 guests)")
+    click_link 'Brooklyn, NY'
     find("#hosting_max_guests").select(9)
     click_button "Save"
-    expect(page).to have_content("11211 (9 guests)")
+    expect(page).to have_content("Brooklyn, NY (9 guests)")
   end
 
   scenario "updating a hosting zip code" do
     create_host
-    expect(page).to have_content("11211 (10 guests)")
-    click_link '11211'
+    expect(page).to have_content("Brooklyn, NY (10 guests)")
+    click_link 'Brooklyn, NY'
     fill_in "Where are you located?", with: '63130'
     find("#hosting_max_guests").select(10)
     click_button "Save"
     expect(page).to have_content("63130 (10 guests)")
+  end
+
+  scenario "geocoder does not return city or state" do
+    create_host('63130', 1)
+    expect(page).to have_content("63130 (1 guest)")
   end
 
 end

--- a/spec/support/feature_test_helper.rb
+++ b/spec/support/feature_test_helper.rb
@@ -51,7 +51,7 @@ module FeatureTestHelper
   end
 
   def delete_host
-    click_link "11211 (10 guests)"
+    click_link "Brooklyn, NY (10 guests)"
     click_link "Delete"
   end
 end


### PR DESCRIPTION
In many places where we used to show the user zip codes, it is more clear if we show city and state. I have changed to "City, State" in new_host_email, visits/show.html.haml, and visit and host decorators. Tests were updated to reflect the changes. If geocoder is missing either city or state, we show zip code instead. I also added a test for showing zip code if city or state are nil