### PR TITLE
Update links temporarily

### DIFF
--- a/app/views/user_mailer/new_host_email.html.erb
+++ b/app/views/user_mailer/new_host_email.html.erb
@@ -8,7 +8,7 @@ Hi <%= @visitor.first_name %>,
   <br><br>
 <% end %>
 
-Do NOT reply to this email! Contact <%= @host.first_name %> by clicking this link: <%= link_to "Contact #{@host.first_name}", "#{ENV['MAILER_URL']}/contacts/email/#{ @visit.id }/#{ @hosting.id }" %><br><br>
+Do NOT reply to this email! In order to contact <%= @host.first_name %> <%= link_to "follow this link", visit_url(@visit) %><br><br>
 
 We strongly recommend that potential hosts and visitors connect over social media before making any housing plans.<br><br>
 

--- a/spec/mailers/new_host_mailer_spec.rb
+++ b/spec/mailers/new_host_mailer_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe UserMailer, type: :mailer do
   end
 
   it 'should contain a results link' do
-    expect(@email).to have_body_text(/Contact #{@host.first_name}/)
+    expect(@email).to have_body_text(/In order to contact #{@host.first_name}/)
   end
 
 


### PR DESCRIPTION
Links in email were broken, causing visitors to not be able to contact hosts that way. This changes the links to go to their search results page, which they can use to contact hosts. This is a quick fix, but we will investigate what went wrong later.