### PR TITLE
Add HR separator line to contacts email; Upgraded 1 gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,7 +353,7 @@ GEM
       activemodel (>= 4.2)
       debug_inspector
       railties (>= 4.2)
-    webmock (2.0.3)
+    webmock (2.1.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff

--- a/app/views/user_mailer/new_contacts_digest.html.erb
+++ b/app/views/user_mailer/new_contacts_digest.html.erb
@@ -2,6 +2,7 @@ Hi <%= @host.first_name %>,
 <br><br>
 Thank you for offering to host volunteers on BernieBNB! Here's all the people who have expressed interest in your offer today, <%= Date.today.strftime('%B %d, %Y') %>:
 <br><br>
+<hr>
 <% @contact_data.map do |cd| %>
   <%= cd[:visitor].first_name %>:<br><br>
   Phone: <%= cd[:visitor].phone %><br>
@@ -9,6 +10,7 @@ Thank you for offering to host volunteers on BernieBNB! Here's all the people wh
   Dates: <%= cd[:visit].start_and_end_dates %><br>
   Group of <%= cd[:visit].num_travelers %>
   <br><br>
+  <hr>
 <% end %>
 <br><br>
 We strongly recommend that potential hosts and visitors connect over social media before making any housing plans.


### PR DESCRIPTION
 * Add HR separator line to contacts email (similar to hosts email).
 * Upgraded 1 gem: webmock.