### PR TITLE
Explicity set config/time_zone to UTC in config/application.rb file

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,7 @@ module BernieBNB
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'UTC'
 
     # The default locale is :en and all translations from
     #    config/locales/*.rb,yml are auto loaded.


### PR DESCRIPTION
Explicitly set config/time_zone to UTC in config/application.rb file.